### PR TITLE
fix: producer.py 복구 및 재추가

### DIFF
--- a/iot-kafka-streaming-project/producer/producer.py
+++ b/iot-kafka-streaming-project/producer/producer.py
@@ -1,0 +1,45 @@
+from kafka import KafkaProducer
+import json
+import time
+import os
+from sensor_generator import generate_sensor_data
+from dotenv import load_dotenv
+
+# .env 파일을 읽어와 환경 변수 설정
+load_dotenv()
+
+# Kafka 서버 정보와 토픽 이름을 환경 변수에서 불러오기
+KAFKA_BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "host.docker.internal:9092")
+KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "sensor_data")
+
+# KafkaProducer 인스턴스 생성
+producer = KafkaProducer(
+    bootstrap_servers=KAFKA_BOOTSTRAP_SERVERS,
+    value_serializer=lambda v: json.dumps(v).encode('utf-8')  # 데이터를 JSON 형태로 직렬화
+)
+
+def send_sensor_data():
+    """
+    가상의 센서 데이터를 생성하여 Kafka 토픽으로 전송하는 함수.
+    """
+
+    # 1개의 센서 데이터 생성
+    sensor_data = generate_sensor_data()
+
+    # Kafka 토픽으로 데이터 전송
+    producer.send(KAFKA_TOPIC, value=sensor_data)
+
+    # 전송 로그 출력 (개발 편의용)
+    print(f"[Kafka Producer] Sent data: {sensor_data}")
+
+if __name__ == "__main__":
+    # 무한 루프로 주기적으로 데이터 전송
+    try:
+        while True:
+            send_sensor_data()
+            time.sleep(5)  # 5초마다 데이터 전송
+    except KeyboardInterrupt:
+        print("Producer stopped manually.")
+    finally:
+        # 프로듀서 종료
+        producer.close()


### PR DESCRIPTION
## 작업 내용 (What)

- Kafka 프로듀서 기능을 구현했습니다.
- 가상 센서 데이터(sensor_generator.py)로부터 데이터를 생성하여 Kafka 토픽으로 주기적으로 전송합니다.

## 작업 목적 (Why)

- 실시간 스트리밍 데이터 파이프라인 구성을 위해 센서 데이터를 Kafka에 보내는 프로듀서 역할을 개발했습니다.

## 변경 사항 요약 (Changes)

- `producer/producer.py` 파일 추가
  - `sensor_generator.py`로부터 데이터를 받아옴
  - Kafka Topic(`sensor_data`)으로 5초마다 센서 데이터 송신
  - `.env` 파일로 Kafka 서버 주소와 토픽 이름 관리
- 에러 발생 시 안전하게 종료할 수 있도록 `KeyboardInterrupt` 처리

## 확인 요청 사항 (Check Point)

- Kafka 서버 주소(`localhost:9092`)가 정상적으로 설정되어 있는지
- 데이터 송신 주기(5초)가 적절한지 검토 부탁드립니다.

## 기타 사항 (Etc)

- 이후 Kafka Consumer가 이 데이터를 수신하여 InfluxDB에 저장하는 플로우로 연동할 예정입니다.
