### PR TITLE
feat: sensor_generator 내 pm10, pm2.5, co2 센서 추가 및 Dockerfile 작성

### DIFF
--- a/producer/Dockerfile
+++ b/producer/Dockerfile
@@ -1,0 +1,16 @@
+# producer/Dockerfile
+
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# 실행 파일 및 requirements 복사
+COPY producer.py sensor_generator.py ./
+COPY requirements.txt ./
+
+# 공통 모듈 복사
+COPY ../common ./common
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+CMD ["python", "producer.py"]

--- a/producer/producer.py
+++ b/producer/producer.py
@@ -1,0 +1,45 @@
+from kafka import KafkaProducer
+import json
+import time
+import os
+from sensor_generator import generate_sensor_data
+from dotenv import load_dotenv
+
+# .env 파일을 읽어와 환경 변수 설정
+load_dotenv()
+
+# Kafka 서버 정보와 토픽 이름을 환경 변수에서 불러오기
+KAFKA_BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "host.docker.internal:9092")
+KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "sensor_data")
+
+# KafkaProducer 인스턴스 생성
+producer = KafkaProducer(
+    bootstrap_servers=KAFKA_BOOTSTRAP_SERVERS,
+    value_serializer=lambda v: json.dumps(v).encode('utf-8')  # 데이터를 JSON 형태로 직렬화
+)
+
+def send_sensor_data():
+    """
+    가상의 센서 데이터를 생성하여 Kafka 토픽으로 전송하는 함수.
+    """
+
+    # 1개의 센서 데이터 생성
+    sensor_data = generate_sensor_data()
+
+    # Kafka 토픽으로 데이터 전송
+    producer.send(KAFKA_TOPIC, value=sensor_data)
+
+    # 전송 로그 출력 (개발 편의용)
+    print(f"[Kafka Producer] Sent data: {sensor_data}")
+
+if __name__ == "__main__":
+    # 무한 루프로 주기적으로 데이터 전송
+    try:
+        while True:
+            send_sensor_data()
+            time.sleep(5)  # 5초마다 데이터 전송
+    except KeyboardInterrupt:
+        print("Producer stopped manually.")
+    finally:
+        # 프로듀서 종료
+        producer.close()

--- a/producer/sensor_generator.py
+++ b/producer/sensor_generator.py
@@ -1,0 +1,54 @@
+import random
+from datetime import datetime
+
+
+def generate_sensor_data():
+    """
+    가상의 센서 데이터(온도, 습도, 기압, 미세먼지, 초미세먼지, co2농도)을 생성하는 함수,
+    매 호출 시마다 새로운 랜덤 값을 반환한다.
+
+    :return:
+        dict: 센서 데이터 (timestamp, temperature, humidity, pressure, pm10, pm25, co2)
+    """
+
+    # 현재 UTC 기준 시간 생성 (글로벌 표준성 및 시간대 이슈 제거를 위해 UTC 설정)
+    timestamp = datetime.utcnow().isoformat()
+
+    # 온도(°C) 생성: 15°C ~ 30~ 범위
+    temperature = round(random.uniform(15.0, 30.0), 2)
+
+    # 습도(%) 생성: 30% ~ 90% 범위
+    humidity = round(random.uniform(30.0, 90.0), 2)
+
+    # 기압(hPa) 생성: 950hPa ~ 1050hPa 범위
+    pressure = round(random.uniform(950.0, 1050), 2)
+
+    # 미세먼지(μg/m³) 생성: 0μg/m³ ~ 150μg/m³ 범위
+    pm10 = round(random.uniform(0.0, 150.0), 2)
+
+    # 초미세먼지(μg/m³) 생성: 0μg/m³ ~ 100μg/m³ 범위
+    pm25 = round(random.uniform(0.0, 100.0), 2)
+
+    # 이산화탄소 농도(ppm) 생성: 400ppm ~ 1000ppm 범위
+    co2 = round(random.uniform(400.0, 1000.0), 2)
+
+    # 생성된 데이터들을 딕셔너리로 반환
+    sensor_data = {
+        "timestamp": timestamp,
+        "temperature": temperature,
+        "humidity": humidity,
+        "pressure": pressure,
+        "pm10": pm10,
+        "pm25": pm25,
+        "co2": co2
+    }
+
+    return sensor_data
+
+
+# 테스트 용도로 이 파일을 직접 실행했을 때 동작
+if __name__ == "__main__":
+    # 5회 출력해서 정상 작동 여부 확인
+    for _ in range(5):
+        data = generate_sensor_data()
+        print(data)


### PR DESCRIPTION
## 작업 개요
- sensor_generator.py에 새로운 센서 데이터 필드를 추가했습니다.
  - 미세먼지 (PM10, 단위: μg/m³)
  - 초미세먼지 (PM2.5, 단위: μg/m³)
  - 이산화탄소 농도 (CO2, 단위: ppm)

## 주요 변경 사항
- 기존 temperature, humidity, pressure 생성 로직에 더하여
  - PM10, PM2.5, CO2 랜덤 데이터 생성 로직 추가
- 데이터 구조를 확장하여 producer가 전송하는 Kafka 메시지에 자동 반영되도록 구성

## 목적
- 미세먼지, 초미세먼지, 이산화탄소 등 환경 관련 지표를 수집할 수 있도록 데이터 확장
- 이후 Grafana 대시보드 및 이상치 감지 로직에서도 활용할 예정

## 기타 참고 사항
- 관련된 consumer.py 및 InfluxDB 저장 로직(db_writer.py)은 기본 구조상 자동 반영됩니다.
- producer.py는 별도 수정 없이 sensor_generator 확장만으로 연동 완료되었습니다.
