### PR TITLE
feat: 공통 이상치 감지 모듈 사용하도록 작성

### DIFF
--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -1,0 +1,16 @@
+# consumer/Dockerfile
+
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# 실행 파일 및 requirements 복사
+COPY consumer.py db_writer.py ./
+COPY requirements.txt ./
+
+# 공통 모듈 복사
+COPY ../common ./common
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+CMD ["python", "consumer.py"]

--- a/consumer/consumer.py
+++ b/consumer/consumer.py
@@ -1,0 +1,56 @@
+import os
+import json
+from kafka import KafkaConsumer
+from dotenv import load_dotenv
+from db_writer import write_sensor_data_to_influxdb
+from common.anomaly_detector import detect_anomalies
+
+# .env 파일을 읽어와 환경 변수 설정
+load_dotenv()
+
+# Kafka 서버 정보와 토픽 이름을 환경 변수에서 불러오기
+KAFKA_BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "sensor_data")
+
+# KafkaConsumer 인스턴스 생성
+consumer = KafkaConsumer(
+    KAFKA_TOPIC,
+    bootstrap_servers=KAFKA_BOOTSTRAP_SERVERS,
+    auto_offset_reset='earliest',  # 가장 처음 메시지부터 읽기
+    enable_auto_commit=True,       # 메시지를 처음 읽은 후 자동으로 오프셋 커밋
+    group_id='sensor-data-consumer-group',  # Consumer Group ID 설정
+    value_deserializer=lambda m: json.loads(m.decode('utf-8'))  # 메시지를 JSON 디코딩
+)
+
+def consume_sensor_data():
+    """
+    Kafka 토픽에서 실시간으로 센서 데이터를 읽고,
+    이상치 감지 후 InfluxDB에 저장하는 함수.
+    """
+
+    print("[Kafka Consumer] Listening for messages...")
+
+    for message in consumer:
+        # message.value는 JSON 디코딩된 Python dict 객체
+        sensor_data = message.value
+
+        # 수신한 데이터 출력
+        print(f"[Kafka Consumer] Received data: {sensor_data}")
+
+        # 이상치 감지
+        alerts = detect_anomalies(sensor_data)
+        if alerts:
+            for alert in alerts:
+                print(f"[ALERT DETECTED] {alert}")
+
+        # Kafka에서 받은 센서 데이터를 InfluxDB에 저장
+        write_sensor_data_to_influxdb(sensor_data)
+
+if __name__ == "__main__":
+    try:
+        consume_sensor_data()
+    except KeyboardInterrupt:
+        print("Consumer stopped manually.")
+    finally:
+        # Consumer는 특별한 close 호출 없이 안전하게 종료됨
+        pass

--- a/consumer/db_writer.py
+++ b/consumer/db_writer.py
@@ -1,0 +1,67 @@
+from influxdb_client import InfluxDBClient, Point, WritePrecision
+from influxdb_client.client.write_api import SYNCHRONOUS
+import os
+from dotenv import load_dotenv
+
+#.env 파일 로드
+load_dotenv()
+
+# InfluxDB 접속 정보 환경변수에서 불러오기
+INFLUXDB_URL = os.getenv("INFLUXDB_URL", "http://localhost:8086")
+INFLUXDB_TOKEN = os.getenv("INFLUXDB_TOKEN")
+INFLUXDB_ORG = os.getenv("INFLUXDB_ORG")
+INFLUXDB_BUCKET = os.getenv("INFLUXDB_BUCKET")
+
+# InfluxDB 클라이언트 생성
+client = InfluxDBClient(
+    url=INFLUXDB_URL,
+    token=INFLUXDB_TOKEN,
+    org=INFLUXDB_ORG
+)
+
+# Write API (데이터 쓰기 전용)
+write_api = client.write_api(write_options=SYNCHRONOUS)
+
+def write_sensor_data_to_influxdb(sensor_data: dict):
+    """
+    센서 데이터를 InfluxDB에 저장하는 함수.
+
+    Args:
+        sensor_data (dict): 센서 데이터 (timestamp, temperacture, humidity, pressure, pm10, pm25, co2)
+    """
+
+    # InfluxDB에 저장할 포인트 데이터 생성
+    point = (
+        Point("sensor_measurements")    # Measurement 이름 (ex: 테이블 비슷한 개념)
+        .tag("device", "virtual_sensor_01")      # 태그: 기기 식별자
+        .field("temperature", sensor_data["temperature"])   # 필드: 온도 값
+        .field("humidity", sensor_data["humidity"])         # 필드: 습도 값
+        .field("pressure", sensor_data["pressure"])         # 필드: 기압 값
+        .field("pm10", sensor_data["pm10"])                 # 필드: 미세먼지 값
+        .field("pm25", sensor_data["pm25"])                 # 필드: 초미세먼지 값
+        .field("co2", sensor_data["co2"])                   # 필드: co2 농도 값
+        .time(sensor_data["timestamp"], WritePrecision.NS)  # 시간: 초 단위로 저장
+    )
+
+    # 데이터 쓰기 (버킷 지정)
+    write_api.write(
+        bucket=INFLUXDB_BUCKET,
+        org=INFLUXDB_ORG,
+        record=point
+    )
+
+    # 저장 성공 로그
+    print(f"[InfluxDB] Data written: {sensor_data}")
+
+if __name__ == "__main__":
+    # 테스트용 코드
+    test_data = {
+        "timestamp": "2024-04-27T06:30:00Z",
+        "temperature": 23.5,
+        "humidity": 45.2,
+        "pressure": 1012.3,
+        "pm10": 30.0,
+        "pm25": 15.0,
+        "co2": 500.0
+    }
+    write_sensor_data_to_influxdb(test_data)


### PR DESCRIPTION
## 작업 개요
- 센서 데이터 확장 및 공통 이상치 감지 모듈 적용을 위한 기능 추가 및 코드 리팩토링 작업입니다.

## 주요 변경사항
- sensor_generator.py에 미세먼지(PM10), 초미세먼지(PM2.5), CO2 필드 추가
- common/anomaly_detector.py 생성 (공통 이상치 감지 로직 분리)
- consumer.py에서 기존 이상치 감지 로직 제거, anomaly_detector 모듈 import 적용
- sensor_etl_dag.py에서도 anomaly_detector 모듈 활용하여 중복 제거
- 디렉터리 구조를 루트 기준으로 플래튼(flatten)하여 관리

## 변경 목적
- 센서 데이터 항목 확장을 통한 다양한 환경 데이터 수집
- 이상치 감지 로직을 공통화하여 유지보수성 개선
- 프로젝트 디렉터리 구조를 간결하게 정리하여 관리 편의성 증대

## 테스트 결과
- Kafka를 통해 확장된 센서 데이터 정상 송신 및 수신 확인
- Consumer에서 이상치 감지 로직 정상 동작 확인
- Grafana 대시보드에서 확장된 데이터 실시간 시각화 확인
- Airflow DAG에서 Kafka/InfluxDB 연결 및 이상치 감지 Task 정상 작동 확인

## 기타
- 향후 anomaly 이벤트를 InfluxDB에 별도 Measurement로 저장하는 기능 추가 예정
- Slack 또는 Email 기반 알림 기능 연동 계획
